### PR TITLE
Added support for libvirt provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ This is an attempt to make it super easy to get set up with a VM you can use to 
 ## Installation
 1. Install a hypervisor. The following hypervisors are supported:
    * VirtualBox (default, recommended)
-   * libvirt (requires vagrant-libvirt provider [here](https://github.com/vagrant-libvirt/vagrant-libvirt))
+   * libvirt (requires vagrant-libvirt provider, which can be found [here](https://github.com/vagrant-libvirt/vagrant-libvirt))
 2. Install Vagrant:
    * OSX: `brew cask install vagrant`
    * Linux: `sudo apt-get install vagrant`
 3. Clone this project and `cd` to clone dir.
 4. Build VM and provision:
-   * VirtualBox: `vagrant up`
-   * libvirt: `vagrant up --provider=libvirt`
+   * If using VirtualBox: `vagrant up`
+   * If using libvirt: `vagrant up --provider=libvirt`
 
 ### Note
 If you're on a Debian-based system and receive a "no usable providers" error, uninstall vagrant, download the .deb package from the official website and install it.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 This is an attempt to make it super easy to get set up with a VM you can use to play CTFs.
 
 ## Installation
-1. Install VirtualBox.
+1. Install a hypervisor. The following hypervisors are supported:
+   * VirtualBox (default, recommended)
+   * libvirt (requires vagrant-libvirt provider [here](https://github.com/vagrant-libvirt/vagrant-libvirt))
 2. Install Vagrant:
    * OSX: `brew cask install vagrant`
    * Linux: `sudo apt-get install vagrant`

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ This is an attempt to make it super easy to get set up with a VM you can use to 
    * OSX: `brew cask install vagrant`
    * Linux: `sudo apt-get install vagrant`
 3. Clone this project and `cd` to clone dir.
-4. Build VM and provision: `vagrant up`
+4. Build VM and provision:
+   * VirtualBox: `vagrant up`
+   * libvirt: `vagrant up --provider=libvirt`
 
 ### Note
 If you're on a Debian-based system and receive a "no usable providers" error, uninstall vagrant, download the .deb package from the official website and install it.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,9 +9,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision :shell, :path => "vagrant_setup.sh", :privileged => false
 
   config.vm.define "pwn", primary: true do |u64|
+    u64.vm.network "private_network", ip: "10.10.10.10"
     u64.vm.provider "virtualbox" do |vb, override|
       override.vm.box ="geerlingguy/ubuntu1604"
-      override.vm.network "private_network", ip: "10.10.10.10"
       # Sync a folder between the host and all guests.
       # Uncomment this line (and adjust as you like)
       #override.vm.synced_folder "~/code", "/code"
@@ -22,8 +22,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
     u64.vm.provider "libvirt" do |lv, override|
       override.vm.box = "algebro/ubuntu1604"
-      override.vm.network "private_network", ip: "10.10.10.10"      
-
+      #override.vm.network "private_network", ip: "10.10.10.10"
+      # Sync a folder between the host and all guests.
+      # Uncomment this line (and adjust as you like)
+      # NOTE: Requires installation of the nfs-server package on the host machine
+      # If `vagrant up` hangs at Mounting NFS folders, modify your firewall configuration
+      # to allow nfs, rpc, and mountd services     
+      override.vm.synced_folder "~/ctf", "/ctf", :nfs => true
       lv.memory = "2048"
       lv.graphics_type = "none"
     end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,19 +12,22 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   #config.vm.synced_folder "~/code", "/code"
 
   config.vm.define "pwn", primary: true do |u64|
-    u64.vm.box = "geerlingguy/ubuntu1604"
-    u64.vm.network "private_network", ip: "10.10.10.10"
-    u64.vm.provider "virtualbox" do |vb|
-      vb.name = "pwn ubuntu"
+    u64.vm.provider "virtualbox" do |vb, override|
+      override.vm.box ="geerlingguy/ubuntu1604"
+      override.vm.network "private_network", ip: "10.10.10.10"
+      
+      vb.name = "pwn-test"
       vb.memory = "2048"
       vb.gui = false
     end
-    u64.vm.box = "algebro/ubuntu1604"
-    u64.vm.network "private_network", ip: "10.10.10.10"
-    u64.vm.provider "libvirt" do |lv|
+    #u64.vm.box = "algebro/ubuntu1604"
+    #u64.vm.network "private_network", ip: "10.10.10.10"
+    u64.vm.provider "libvirt" do |lv, override|
+      override.vm.box = "algebro/ubuntu1604"
+      override.vm.network "private_network", ip: "10.10.10.10"      
+
       lv.memory = "2048"
       lv.graphics_type = "none"
     end
   end
-
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,6 +8,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.ssh.forward_agent = true
   config.vm.provision :shell, :path => "vagrant_setup.sh", :privileged => false
 
+  name = "pwn"
+  memory = "2048"
+
   config.vm.define "pwn", primary: true do |u64|
     u64.vm.network "private_network", ip: "10.10.10.10"
     u64.vm.provider "virtualbox" do |vb, override|
@@ -16,8 +19,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       # Uncomment this line (and adjust as you like)
       #override.vm.synced_folder "~/code", "/code"
 
-      vb.name = "pwn"
-      vb.memory = "2048"
+      vb.name = name
+      vb.memory = memory
       vb.gui = false
     end
     u64.vm.provider "libvirt" do |lv, override|
@@ -28,7 +31,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       # If `vagrant up` hangs at Mounting NFS folders, modify your firewall configuration
       # to allow nfs, rpc, and mountd services     
       #override.vm.synced_folder "~/ctf", "/ctf", :nfs => true
-      lv.memory = "2048"
+      lv.memory = memory
       lv.graphics_type = "none"
     end
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,7 +16,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       override.vm.box ="geerlingguy/ubuntu1604"
       override.vm.network "private_network", ip: "10.10.10.10"
       
-      vb.name = "pwn-test"
+      vb.name = "pwn"
       vb.memory = "2048"
       vb.gui = false
     end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,7 +22,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
     u64.vm.provider "libvirt" do |lv, override|
       override.vm.box = "algebro/ubuntu1604"
-      #override.vm.network "private_network", ip: "10.10.10.10"
       # Sync a folder between the host and all guests.
       # Uncomment this line (and adjust as you like)
       # NOTE: Requires installation of the nfs-server package on the host machine

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,7 +27,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       # NOTE: Requires installation of the nfs-server package on the host machine
       # If `vagrant up` hangs at Mounting NFS folders, modify your firewall configuration
       # to allow nfs, rpc, and mountd services     
-      override.vm.synced_folder "~/ctf", "/ctf", :nfs => true
+      #override.vm.synced_folder "~/ctf", "/ctf", :nfs => true
       lv.memory = "2048"
       lv.graphics_type = "none"
     end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,15 +7,15 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.ssh.username = "vagrant"
   config.ssh.forward_agent = true
   config.vm.provision :shell, :path => "vagrant_setup.sh", :privileged => false
-  # Sync a folder between the host and all guests.
-  # Uncomment this line (and adjust as you like)
-  #config.vm.synced_folder "~/code", "/code"
 
   config.vm.define "pwn", primary: true do |u64|
     u64.vm.provider "virtualbox" do |vb, override|
       override.vm.box ="geerlingguy/ubuntu1604"
       override.vm.network "private_network", ip: "10.10.10.10"
-      
+      # Sync a folder between the host and all guests.
+      # Uncomment this line (and adjust as you like)
+      #override.vm.synced_folder "~/code", "/code"
+
       vb.name = "pwn"
       vb.memory = "2048"
       vb.gui = false

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,6 +19,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       vb.memory = "2048"
       vb.gui = false
     end
+    u64.vm.box = "algebro/ubuntu1604"
+    u64.vm.network "private_network", ip: "10.10.10.10"
+    u64.vm.provider "libvirt" do |lv|
+      lv.memory = "2048"
+      lv.graphics_type = "none"
+    end
   end
 
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,8 +20,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       vb.memory = "2048"
       vb.gui = false
     end
-    #u64.vm.box = "algebro/ubuntu1604"
-    #u64.vm.network "private_network", ip: "10.10.10.10"
     u64.vm.provider "libvirt" do |lv, override|
       override.vm.box = "algebro/ubuntu1604"
       override.vm.network "private_network", ip: "10.10.10.10"      


### PR DESCRIPTION
I mutated geerlingguy's ubuntu 1604 base box to work with libvirt and uploaded it to Vagrant cloud, then modified pwnvm's vagrant file to allow it to use either VirtualBox (default) or libvirt (with --provider=libvirt). Vagrant will download geerlingguy's box as before if VirtualBox is being used, or it will download my base box if libvirt is being used. 